### PR TITLE
Fix surfaceTF energy derivative

### DIFF
--- a/dyson/surfaceTF.cpp
+++ b/dyson/surfaceTF.cpp
@@ -146,12 +146,12 @@ double surfaceTF::derDispersiveE( double E ) {
     }
     else if ( EnergyType == 1 ) {
 
-        TF.deltaVXAboveBelow( Ecm - Efermi ); // Dispersive Correction
+        TF.deltaVXAboveBelow( E - Efermi ); // Dispersive Correction
         TF.findHalfIntegral(); // Needed for Subtracted Dispersive Correction
 
         return TF.derDeltaVAbove(); // Subtracted Dispersive Correction
     }
-    else return TF.derDeltaV(Ecm);
+    else return TF.derDeltaV(E);
 }
 
 //***************************************************************


### PR DESCRIPTION
## Summary
- fix incorrect energy variable usage in `surfaceTF::derDispersiveE`

## Testing
- `g++ -std=c++11 -I. -c surfaceTF.cpp`

------
https://chatgpt.com/codex/tasks/task_e_687b64b3509083279b03b13d26aa10c5